### PR TITLE
Fixed a bug in CircularBuffer.entries() and some minor additions

### DIFF
--- a/lib/CircularBuffer.js
+++ b/lib/CircularBuffer.js
@@ -16,8 +16,8 @@
      * @param capacity {Number=} default is 32
      */
     function CircularBuffer(capacity) {
-        this._capacity = typeof capacity === 'number'
-            && capacity !== 0 ? capacity : 32;
+        this._capacity = typeof capacity === 'number' &&
+            capacity !== 0 ? capacity : 32;
         this._end = 0;
         this._st = -1;
         this._buf = [];
@@ -32,7 +32,9 @@
      * @returns this {CircularBuffer}
      */
     CircularBuffer.prototype.add = function (obj) {
-        if (obj === undefined || obj === null)throw new Error("Null/Undefined values are not supported");
+        if (obj === undefined || obj === null) {
+            throw new Error("Null/Undefined values are not supported");
+        }
         this._buf[this._end] = obj;
         if (this._end === this._st || this._st === -1) {
             //advance head
@@ -57,6 +59,7 @@
             case 1:
                 delete this._buf[this._st];
                 this._st = -1;
+                this._end = 0; //equivalent to clear
                 break;
             default:
                 delete this._buf[this._st];
@@ -124,6 +127,7 @@
     CircularBuffer.prototype.clear = function () {
         this._st = -1;
         this._end = 0;
+        this._buf = [];
     }
 
     /**
@@ -133,13 +137,15 @@
      * @returns {Array} Array of all entries in Buffer
      */
     CircularBuffer.prototype.entries = function () {
-        var start = this._st,
-            end= (this._end || this._capacity)-1,
-            entries = [];
-        while (start != -1 && start <= end) {
-            entries.push(this._buf[start++]);
+        if (this._st === -1) {
+            return [];
         }
-        return entries;
+        if (this._st>=this._end) {
+            return this._buf.slice(this._st,this._capacity).concat(this._buf.slice(0,this._end));
+        }
+        else {
+            return this._buf.slice(this._st,this._end);
+        }
     }
 
     /**

--- a/tests/TestCircularBuffer.js
+++ b/tests/TestCircularBuffer.js
@@ -108,6 +108,61 @@ var CircularBuffer = require('../lib/CircularBuffer.js'), assert = require('asse
         assert.deepEqual(cb.front(),4);
         cb.remove();
         assert.deepEqual(cb.isEmpty(),true);
+
+        cb.clear();
+        //Test that cb.entries() behaves correctly for all _st and _end positions
+        var expect = [92,93,94,95,96,97,98,99,100,101];
+        for(i=1;i<=100;i++){
+            cb.add(i);
+        }
+        for (i=1;i<=19;i++) {
+            cb.add(100+i);
+            assert.deepEqual(cb.front(),expect[0]);
+            assert.deepEqual(cb.back(),expect[expect.length-1]);
+            assert.deepEqual(cb.entries(),expect);
+
+            expect.shift();
+            expect.push(100+i+1);
+        }
+
+        expect = [111,112,113,114,115,116,117,118,119];
+        cb.remove();
+
+        console.log(cb);
+        assert.deepEqual(cb.entries(),expect);
+
+
+        cb.remove();
+        expect.shift();
+        assert.deepEqual(cb.entries(),expect);
+        cb.remove();
+        expect.shift();
+        assert.deepEqual(cb.entries(),expect);
+        cb.remove();
+        expect.shift();
+        assert.deepEqual(cb.entries(),expect);
+        cb.remove();
+        expect.shift();
+        assert.deepEqual(cb.entries(),expect);
+        cb.remove();
+        expect.shift();
+        assert.deepEqual(cb.entries(),expect);
+        cb.remove();
+        expect.shift();
+        assert.deepEqual(cb.entries(),expect);
+        cb.remove();
+        expect.shift();
+        assert.deepEqual(cb.entries(),expect);
+        cb.remove();
+        expect.shift();
+        assert.deepEqual(cb.entries(),expect);
+        cb.remove();
+        expect.shift();
+
+        console.log(cb);
+        assert.deepEqual(cb.entries(),expect);
+        console.log(cb._buf.length);
+
     }
 
     function assertAll(cb,size,st,end,buf,capacity){
@@ -127,7 +182,7 @@ var CircularBuffer = require('../lib/CircularBuffer.js'), assert = require('asse
             i++;
         }
     }
-    testInvariants()
+    testInvariants();
     addTest();
     addAndRemoveTest();
     addManyTest();


### PR DESCRIPTION
Fixed a bug in CircularBuffer.entries() that returned an empty list when _end was not aligned with the internal buffer. Also modified entries() to use calls to slice() and concat() instead of a while loop and push()
